### PR TITLE
Bump PHPStan to ^2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require-dev": {
         "editorconfig-checker/editorconfig-checker": "^10.3.0",
         "ergebnis/composer-normalize": "^2.19",
-        "phpstan/phpstan": "^2.1",
+        "phpstan/phpstan": "^2.2",
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^10.5.62 || ^11.5.50",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9cafae10ad1dffbea91c5001f63da28d",
+    "content-hash": "42a4bf29fba826e60fc756cb350aebdc",
     "packages": [
         {
             "name": "nette/schema",
@@ -1268,11 +1268,11 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "2.1.54",
+            "version": "2.2.0",
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/8be50c3992107dc837b17da4d140fbbdf9a5c5bd",
-                "reference": "8be50c3992107dc837b17da4d140fbbdf9a5c5bd",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/b4cd98348c809924f62bb9cc8c047f5e73bc9a58",
+                "reference": "b4cd98348c809924f62bb9cc8c047f5e73bc9a58",
                 "shasum": ""
             },
             "require": {
@@ -1294,6 +1294,17 @@
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ondřej Mirtes"
+                },
+                {
+                    "name": "Markus Staab"
+                },
+                {
+                    "name": "Vincent Langlet"
+                }
             ],
             "description": "PHPStan - PHP Static Analysis Tool",
             "keywords": [
@@ -1317,7 +1328,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-29T13:31:09+00:00"
+            "time": "2026-05-28T08:22:43+00:00"
         },
         {
             "name": "phpstan/phpstan-phpunit",

--- a/src/DetectionConfig.php
+++ b/src/DetectionConfig.php
@@ -19,7 +19,6 @@ use function is_readable;
 use function json_decode;
 use function realpath;
 use const DIRECTORY_SEPARATOR;
-use const JSON_PRESERVE_ZERO_FRACTION;
 use const JSON_THROW_ON_ERROR;
 
 class DetectionConfig
@@ -111,7 +110,7 @@ class DetectionConfig
 
         try {
             /** @throws JsonException */
-            $configArray = json_decode($configData, true, 512, JSON_PRESERVE_ZERO_FRACTION | JSON_THROW_ON_ERROR);
+            $configArray = json_decode($configData, true, 512, JSON_THROW_ON_ERROR);
         } catch (JsonException $e) {
             throw new InvalidConfigException("Failure while parsing JSON in $configFilePath: {$e->getMessage()}", $e);
         }


### PR DESCRIPTION
## Summary
- Bump `phpstan/phpstan` constraint to `^2.2` (lock to 2.2.0)
- Fix the new `argument.invalidConstant` violation: `JSON_PRESERVE_ZERO_FRACTION` was passed to `json_decode` but is an encode-only flag — removed it (and its `use const` import)

## Test plan
- [x] `composer check` (cs, types, tests, dependencies, self-detection) passes

Co-Authored-By: Claude Code