### PR TITLE
Adopt new shipmonk/coding-standard custom sniffs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^10.5.62 || ^11.5.50",
-        "shipmonk/coding-standard": "^0.2.0",
+        "shipmonk/coding-standard": "dev-add-generic-custom-sniffs",
         "shipmonk/composer-dependency-analyser": "^1.0.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
         "phpstan/phpstan-phpunit": "^2.0",
         "phpstan/phpstan-strict-rules": "^2.0",
         "phpunit/phpunit": "^10.5.62 || ^11.5.50",
-        "shipmonk/coding-standard": "dev-add-generic-custom-sniffs",
+        "shipmonk/coding-standard": "^0.3.0",
         "shipmonk/composer-dependency-analyser": "^1.0.0"
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5273054de67902dd39e79ccf0c83de5d",
+    "content-hash": "d9bfd76bda52bf317b243938ddec2b9b",
     "packages": [
         {
             "name": "nette/schema",
@@ -2882,21 +2882,21 @@
         },
         {
             "name": "shipmonk/coding-standard",
-            "version": "dev-add-generic-custom-sniffs",
+            "version": "0.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/shipmonk-rnd/coding-standard.git",
-                "reference": "0bc44b528497e379e30641edde64b9d425795a7a"
+                "reference": "15182bf6b0e17682990c049dd17f593d3235ec62"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/shipmonk-rnd/coding-standard/zipball/0bc44b528497e379e30641edde64b9d425795a7a",
-                "reference": "0bc44b528497e379e30641edde64b9d425795a7a",
+                "url": "https://api.github.com/repos/shipmonk-rnd/coding-standard/zipball/15182bf6b0e17682990c049dd17f593d3235ec62",
+                "reference": "15182bf6b0e17682990c049dd17f593d3235ec62",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
-                "php": "^7.4 || ^8.0",
+                "php": "^8.1",
                 "slevomat/coding-standard": "^8.28.0",
                 "squizlabs/php_codesniffer": "^4.0.1"
             },
@@ -2907,9 +2907,9 @@
                 "phpstan/phpstan": "^2.1",
                 "phpstan/phpstan-phpunit": "^2.0",
                 "phpstan/phpstan-strict-rules": "^2.0",
-                "phpunit/phpunit": "^9.6",
+                "phpunit/phpunit": "^10.5.62",
                 "shipmonk/composer-dependency-analyser": "^1.8",
-                "shipmonk/dead-code-detector": "^0.12",
+                "shipmonk/dead-code-detector": "^1.0",
                 "shipmonk/name-collision-detector": "^2.1",
                 "shipmonk/phpstan-rules": "^4.1"
             },
@@ -2926,9 +2926,9 @@
             "description": "PHP Coding Standard used in ShipMonk",
             "support": {
                 "issues": "https://github.com/shipmonk-rnd/coding-standard/issues",
-                "source": "https://github.com/shipmonk-rnd/coding-standard/tree/add-generic-custom-sniffs"
+                "source": "https://github.com/shipmonk-rnd/coding-standard/tree/0.3.0"
             },
-            "time": "2026-06-22T10:52:55+00:00"
+            "time": "2026-06-23T07:41:40+00:00"
         },
         {
             "name": "shipmonk/composer-dependency-analyser",
@@ -3245,9 +3245,7 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "shipmonk/coding-standard": 20
-    },
+    "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -2886,12 +2886,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/shipmonk-rnd/coding-standard.git",
-                "reference": "556e3d2499dec123904ec09d90e5d1d8a2b36844"
+                "reference": "0bc44b528497e379e30641edde64b9d425795a7a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/shipmonk-rnd/coding-standard/zipball/556e3d2499dec123904ec09d90e5d1d8a2b36844",
-                "reference": "556e3d2499dec123904ec09d90e5d1d8a2b36844",
+                "url": "https://api.github.com/repos/shipmonk-rnd/coding-standard/zipball/0bc44b528497e379e30641edde64b9d425795a7a",
+                "reference": "0bc44b528497e379e30641edde64b9d425795a7a",
                 "shasum": ""
             },
             "require": {
@@ -2928,7 +2928,7 @@
                 "issues": "https://github.com/shipmonk-rnd/coding-standard/issues",
                 "source": "https://github.com/shipmonk-rnd/coding-standard/tree/add-generic-custom-sniffs"
             },
-            "time": "2026-06-22T07:30:14+00:00"
+            "time": "2026-06-22T10:52:55+00:00"
         },
         {
             "name": "shipmonk/composer-dependency-analyser",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "42a4bf29fba826e60fc756cb350aebdc",
+    "content-hash": "5273054de67902dd39e79ccf0c83de5d",
     "packages": [
         {
             "name": "nette/schema",
@@ -168,16 +168,16 @@
     "packages-dev": [
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.2.0",
+            "version": "v1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1"
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/845eb62303d2ca9b289ef216356568ccc075ffd1",
-                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
+                "reference": "963f0c67bffde0eac41b56be71ac0e8ba132f0bd",
                 "shasum": ""
             },
             "require": {
@@ -260,7 +260,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-11T04:32:07+00:00"
+            "time": "2026-05-06T08:26:05+00:00"
         },
         {
             "name": "editorconfig-checker/editorconfig-checker",
@@ -2882,21 +2882,23 @@
         },
         {
             "name": "shipmonk/coding-standard",
-            "version": "0.2.4",
+            "version": "dev-add-generic-custom-sniffs",
             "source": {
                 "type": "git",
                 "url": "https://github.com/shipmonk-rnd/coding-standard.git",
-                "reference": "ca7fa071f5943d87f67e791fe36a691a36d10275"
+                "reference": "556e3d2499dec123904ec09d90e5d1d8a2b36844"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/shipmonk-rnd/coding-standard/zipball/ca7fa071f5943d87f67e791fe36a691a36d10275",
-                "reference": "ca7fa071f5943d87f67e791fe36a691a36d10275",
+                "url": "https://api.github.com/repos/shipmonk-rnd/coding-standard/zipball/556e3d2499dec123904ec09d90e5d1d8a2b36844",
+                "reference": "556e3d2499dec123904ec09d90e5d1d8a2b36844",
                 "shasum": ""
             },
             "require": {
+                "ext-tokenizer": "*",
                 "php": "^7.4 || ^8.0",
-                "slevomat/coding-standard": "^8.28.0"
+                "slevomat/coding-standard": "^8.28.0",
+                "squizlabs/php_codesniffer": "^4.0.1"
             },
             "require-dev": {
                 "editorconfig-checker/editorconfig-checker": "^10.6",
@@ -2914,7 +2916,7 @@
             "type": "phpcodesniffer-standard",
             "autoload": {
                 "psr-4": {
-                    "ShipMonk\\CodingStandard\\": "ShipMonkCodingStandard/"
+                    "ShipMonkCodingStandard\\": "ShipMonkCodingStandard/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2924,9 +2926,9 @@
             "description": "PHP Coding Standard used in ShipMonk",
             "support": {
                 "issues": "https://github.com/shipmonk-rnd/coding-standard/issues",
-                "source": "https://github.com/shipmonk-rnd/coding-standard/tree/0.2.4"
+                "source": "https://github.com/shipmonk-rnd/coding-standard/tree/add-generic-custom-sniffs"
             },
-            "time": "2026-03-16T16:23:10+00:00"
+            "time": "2026-06-22T07:30:14+00:00"
         },
         {
             "name": "shipmonk/composer-dependency-analyser",
@@ -2996,20 +2998,20 @@
         },
         {
             "name": "slevomat/coding-standard",
-            "version": "8.28.1",
+            "version": "8.29.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/slevomat/coding-standard.git",
-                "reference": "66151cfbd25b50e8becd9f809fb704f01fd4d6f2"
+                "reference": "81fce13c4ef4b53a03e5cfa6ce36afc191c1598e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/66151cfbd25b50e8becd9f809fb704f01fd4d6f2",
-                "reference": "66151cfbd25b50e8becd9f809fb704f01fd4d6f2",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/81fce13c4ef4b53a03e5cfa6ce36afc191c1598e",
+                "reference": "81fce13c4ef4b53a03e5cfa6ce36afc191c1598e",
                 "shasum": ""
             },
             "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.2.0",
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7 || ^1.2.1",
                 "php": "^7.4 || ^8.0",
                 "phpstan/phpdoc-parser": "^2.3.2",
                 "squizlabs/php_codesniffer": "^4.0.1"
@@ -3017,11 +3019,11 @@
             "require-dev": {
                 "phing/phing": "3.0.1|3.1.2",
                 "php-parallel-lint/php-parallel-lint": "1.4.0",
-                "phpstan/phpstan": "2.1.42",
+                "phpstan/phpstan": "2.1.54",
                 "phpstan/phpstan-deprecation-rules": "2.0.4",
                 "phpstan/phpstan-phpunit": "2.0.16",
-                "phpstan/phpstan-strict-rules": "2.0.10",
-                "phpunit/phpunit": "9.6.34|10.5.63|11.4.4|11.5.50|12.5.14"
+                "phpstan/phpstan-strict-rules": "2.0.11",
+                "phpunit/phpunit": "9.6.34|10.5.63|11.4.4|11.5.55|12.5.24"
             },
             "type": "phpcodesniffer-standard",
             "extra": {
@@ -3045,7 +3047,7 @@
             ],
             "support": {
                 "issues": "https://github.com/slevomat/coding-standard/issues",
-                "source": "https://github.com/slevomat/coding-standard/tree/8.28.1"
+                "source": "https://github.com/slevomat/coding-standard/tree/8.29.0"
             },
             "funding": [
                 {
@@ -3057,7 +3059,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-22T17:22:38+00:00"
+            "time": "2026-05-07T05:48:08+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -3243,7 +3245,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": {
+        "shipmonk/coding-standard": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {


### PR DESCRIPTION
Bumps `shipmonk/coding-standard` to `^0.3.0`, which adds the new ShipMonk custom sniffs, and applies the auto-fixable results (`phpcbf`).

Co-Authored-By: Claude Code